### PR TITLE
Add a couple of tweaks in docs

### DIFF
--- a/docs/color.md
+++ b/docs/color.md
@@ -9,24 +9,24 @@ A set of utilities around RGB and HSL colors, including CSS color string handlin
 ### Example
 
 ```js
-const Color = require('canvas-sketch-util/color');
+const color = require('canvas-sketch-util/color');
 
 // Parse HSL values from a named CSS color
-const [ h, s, l ] = Color.parse('crimson').hsl;
+const [ h, s, l ] = color.parse('crimson').hsl;
 //> [ 348, 83, 47 ]
 
 // Offset the H, S, L components of a color
-const newColor = Color.offsetHSL('#f0e68c', 5, 10, -15).hex;
+const newColor = color.offsetHSL('#f0e68c', 5, 10, -15).hex;
 //> '#f2ef40'
 
 // Compare two colors to get the contrast ratio
-const ratio = Color.contrastRatio('red', 'hsl(200, 0%, 0%)')
+const ratio = color.contrastRatio('red', 'hsl(200, 0%, 0%)')
 //> 5.252
 
 // Blend two colors together with transparency
 const background = 'white';
 const foreground = 'rgba(250, 0, 0, 0.5)';
-const result = Color.blend(background, foreground);
+const result = color.blend(background, foreground);
 ```
 
 ### Functions
@@ -44,7 +44,7 @@ const result = Color.blend(background, foreground);
 
 <a name="parse"></a>
 
-### `result = Color.parse(input)`
+### `result = color.parse(input)`
 
 Parses the `input` into a "color" object, which provides hex, RGBA and HSLA data. The input can be of the following formats:
 
@@ -61,11 +61,11 @@ Parses the `input` into a "color" object, which provides hex, RGBA and HSLA data
 For example, all of the following are valid:
 
 ```js
-Color.parse('rgba(0, 255, 0, 0.25)');
-Color.parse([ 0, 255, 0, 0.25 ]);
-Color.parse('#00ff0040');
-Color.parse('hsla(120, 100, 50, 0.25)');
-Color.parse({ hsla: [ 120, 100, 50, 0.25 ] });
+color.parse('rgba(0, 255, 0, 0.25)');
+color.parse([ 0, 255, 0, 0.25 ]);
+color.parse('#00ff0040');
+color.parse('hsla(120, 100, 50, 0.25)');
+color.parse({ hsla: [ 120, 100, 50, 0.25 ] });
 ```
 
 The above colors all produce the same color `result`, a semi-transparent green:
@@ -85,39 +85,39 @@ The above colors all produce the same color `result`, a semi-transparent green:
 
 <a name="style"></a>
 
-### `result = Color.style(input)`
+### `result = color.style(input)`
 
 Takes a color input (string, object or array) and returns a CSS color string in the form of `rgb(r, g, b)` or `rgba(r, g, b, a)`.
 
 This is useful to get a consistent string format out of various color input types.
 
 ```js
-document.body.style.background = Color.style([ 255, 120, 50, 0.25 ]);
+document.body.style.background = color.style([ 255, 120, 50, 0.25 ]);
 ```
 
 <a name="relative-luminance"></a>
 
-### `luminance = Color.relativeLuminance(input)`
+### `luminance = color.relativeLuminance(input)`
 
 Gets a [relative luminance](https://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef) number from an input color (string, object or array).
 
 <a name="contrast-ratio"></a>
 
-### `ratio = Color.contrastRatio(inputA, inputB)`
+### `ratio = color.contrastRatio(inputA, inputB)`
 
 Gets a WCAG [contrast ratio](https://www.w3.org/TR/WCAG20-TECHS/G18.html) between two color inputs (either can be strings, objects or arrays).
 
-### `result = Color.offsetHSL(input, h = 0, s = 0, l = 0)`
+### `result = color.offsetHSL(input, h = 0, s = 0, l = 0)`
 
 Parses `input` as a color, then offsets its hue, saturation and lightness by the specified parameters, and returns a newly parsed color object.
 
 ```js
 const base = '#d28879';
 
-console.log(Color.parse(base).hsl);
+console.log(color.parse(base).hsl);
 //> [ 10, 50, 65 ]
 
-const result = Color.offsetHSL(base, 15, 5, -10);
+const result = color.offsetHSL(base, 15, 5, -10);
 console.log(result.hsl);
 //> [ 25, 55, 55 ]
 
@@ -129,18 +129,18 @@ Hue will wrap around between 0-360, and saturation and lightness will be clamped
 
 <a name="blend"></a>
 
-### `result = Color.blend(background, foreground, opacity = 1.0)`
+### `result = color.blend(background, foreground, opacity = 1.0)`
 
 Blends the `foreground` color on top of the `background`, applying the specified `opacity` to the foreground while blending. Either color input can be as strings, objects or arrays. The `result` is a new color object after blending.
 
 <a name="names"></a>
 
-### `map = Color.names`
+### `map = color.names`
 
 A dictionary of CSS color names mapped to their corresponding hex colors.
 
 ```js
-const hex = Color.names['peachpuff'];
+const hex = color.names['peachpuff'];
 //> '#ffdab9'
 ```
 

--- a/docs/random.md
+++ b/docs/random.md
@@ -13,7 +13,7 @@ By default, random values are not deterministic, but if you set a seed with `set
 ```js
 const random = require('canvas-sketch-util/random');
 
-// Random betwee 0 (inclusive) and 1 (exclusive)
+// Random between 0 (inclusive) and 1 (exclusive)
 const r = random.value();
 
 // Random 2D point on unit circle


### PR DESCRIPTION
1. Fixed a typo in `random`

2. In `color`, the code examples use a Capital case where the module is imported as the module default:
```
const Color = require('canvas-sketch-util/color')`
```

The module is exported lowercase, so the examples can lead to `Uncaught TypeError` issues if imported using destructuring: 

```
const { Color, random } = require('canvas-sketch-util')

const luminance = Color.relativeLuminance( 'red' )
// Uncaught TypeError: Cannot read property 'relativeLuminance' of undefined
```

Changing this to lowercase hopefully makes this more consistent with the other modules in the library, and will help avoid potential errors when people copy-paste example code